### PR TITLE
042419IC fix dictionary iteration version

### DIFF
--- a/mrq/basetasks/utils.py
+++ b/mrq/basetasks/utils.py
@@ -1,3 +1,4 @@
+import sys
 from __future__ import print_function
 from future.utils import itervalues
 from future.builtins import str
@@ -153,8 +154,10 @@ class JobAction(Task):
                     self.collection.update({
                         "_id": {"$in": jobs_by_queue[queue]}
                     }, {"$set": updates}, multi=True)
-
-                set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})
+                if sys.version_info.major > 2
+                    set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.items()})
+                else:
+                    set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})
         elif action == 'delete':
             amount_delete = self.collection.delete_many(query)
             stats["deleted"] = amount_delete.deleted_count

--- a/mrq/basetasks/utils.py
+++ b/mrq/basetasks/utils.py
@@ -154,7 +154,7 @@ class JobAction(Task):
                     self.collection.update({
                         "_id": {"$in": jobs_by_queue[queue]}
                     }, {"$set": updates}, multi=True)
-                if sys.version_info.major > 2
+                if sys.version_info.major > 2:
                     set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.items()})
                 else:
                     set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})

--- a/mrq/basetasks/utils.py
+++ b/mrq/basetasks/utils.py
@@ -1,4 +1,3 @@
-import sys
 from __future__ import print_function
 from future.utils import itervalues
 from future.builtins import str
@@ -11,6 +10,7 @@ from collections import defaultdict
 from mrq.utils import group_iter
 import datetime
 import ujson as json
+import sys
 
 
 def get_task_cfg(taskpath):

--- a/mrq/version.py
+++ b/mrq/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.9.15"
+VERSION = "0.9.16"
 
 if __name__ == "__main__":
   import sys

--- a/mrq/version.py
+++ b/mrq/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.9.16"
+VERSION = "0.9.17"
 
 if __name__ == "__main__":
   import sys

--- a/mrq/version.py
+++ b/mrq/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.9.14"
+VERSION = "0.9.15"
 
 if __name__ == "__main__":
   import sys


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.7/site-packages/mrq/worker.py", line 666, in perform_job
    job.perform()
  File "/app/.heroku/python/lib/python3.7/site-packages/mrq/job.py", line 293, in perform
    result = self.task.run_wrapped(self.data["params"])
  File "/app/.heroku/python/lib/python3.7/site-packages/mrq/task.py", line 20, in run_wrapped
    return self.run(params)
  File "/app/.heroku/python/lib/python3.7/site-packages/mrq/basetasks/utils.py", line 32, in run
    self.params.get("action"), query, self.params.get("destination_queue")
  File "/app/.heroku/python/lib/python3.7/site-packages/mrq/basetasks/utils.py", line 155, in perform_action
    set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})
AttributeError: 'collections.defaultdict' object has no attribute 'iteritems'
```