### PR TITLE
Add get latest jobs query

### DIFF
--- a/mrq/job.py
+++ b/mrq/job.py
@@ -656,7 +656,7 @@ class Job(object):
 
 def get_latest_jobs_with_query(query):
         jobs = context.connections.mongodb_jobs.mrq_jobs
-        tasks = jobs.find(query)
+        tasks = jobs.find(query, sort=[('datequeued', DESCENDING)])
         return tasks
 
 def get_latest_job_with_query(query):

--- a/mrq/job.py
+++ b/mrq/job.py
@@ -654,6 +654,11 @@ class Job(object):
             w=1
         )
 
+def get_latest_jobs_with_query(query):
+        jobs = context.connections.mongodb_jobs.mrq_jobs
+        tasks = jobs.find(query)
+        return tasks
+
 def get_latest_job_with_query(query):
         jobs = context.connections.mongodb_jobs.mrq_jobs
         task = jobs.find_one(query, sort=[('datequeued', DESCENDING)])

--- a/mrq/version.py
+++ b/mrq/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.9.20"
+VERSION = "0.9.21"
 
 if __name__ == "__main__":
   import sys


### PR DESCRIPTION
- Taking `get_latest_job_with_query` as model and replacing `find_one` for `find` to get multiple records from mongo.
- Removing sort since we're getting all records by that query.