### PR TITLE
A3S-1593 

### DIFF
--- a/mrq/context.py
+++ b/mrq/context.py
@@ -13,6 +13,8 @@ import traceback
 from .utils import LazyObject, load_class_by_path
 from .config import get_config
 from .subpool import subpool_map, subpool_imap
+from .exceptions import JobRuntimeError
+
 
 # This should be MRQ's only Python object shared by all the jobs in the same process
 _GLOBAL_CONTEXT = {
@@ -113,10 +115,14 @@ def get_current_config():
     return _GLOBAL_CONTEXT["config"]
 
 
-def retry_current_job(delay=None, max_retries=None, queue=None):
+def retry_current_job(delay=None, max_retries=None, queue=None, exception=None):
     current_job = get_current_job()
     if current_job:
         current_job.retry(delay=delay, max_retries=max_retries, queue=queue)
+    elif exception:
+        raise JobRuntimeError("Error during MRQ task execution") from exception
+    else:
+        raise JobRuntimeError("Error during MRQ task execution")
 
 
 def abort_current_job():

--- a/mrq/exceptions.py
+++ b/mrq/exceptions.py
@@ -70,3 +70,7 @@ class MaxConcurrencyInterrupt(_MrqInterrupt):
         return "%s" % (
             self.path
         )
+
+
+class JobRuntimeError(_MrqInterrupt):
+    pass

--- a/mrq/version.py
+++ b/mrq/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.9.28.1"
+VERSION = "0.9.29"
 
 if __name__ == "__main__":
   import sys


### PR DESCRIPTION
if "retry_current_job" is called outside of an MRQ context, then raise exception.
Thus, the actual worker performing the execution of this task can use its own error handling. E.g. Lambda function.